### PR TITLE
Add configurable flows API path

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/admin/index.js
+++ b/packages/node_modules/@node-red/editor-api/lib/admin/index.js
@@ -39,14 +39,15 @@ module.exports = {
 
         const adminApp = apiUtil.createExpressApp(settings)
 
+        const flowsUrl = (settings.flowsUrl || "/flows").replace(/\/+$/, "");
         // Flows
-        adminApp.get("/flows",needsPermission("flows.read"),flows.get,apiUtil.errorHandler);
-        adminApp.post("/flows",needsPermission("flows.write"),flows.post,apiUtil.errorHandler);
+        adminApp.get(flowsUrl, needsPermission("flows.read"), flows.get, apiUtil.errorHandler);
+        adminApp.post(flowsUrl, needsPermission("flows.write"), flows.post, apiUtil.errorHandler);
 
         // Flows/state
-        adminApp.get("/flows/state", needsPermission("flows.read"), flows.getState, apiUtil.errorHandler);
+        adminApp.get(flowsUrl + "/state", needsPermission("flows.read"), flows.getState, apiUtil.errorHandler);
         if (settings.runtimeState && settings.runtimeState.enabled === true) {
-            adminApp.post("/flows/state", needsPermission("flows.write"), flows.postState, apiUtil.errorHandler);
+            adminApp.post(flowsUrl + "/state", needsPermission("flows.write"), flows.postState, apiUtil.errorHandler);
         }
 
         // Flow

--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -235,12 +235,13 @@ var RED = (function() {
 
     function loadFlows(done) {
         loader.reportProgress(RED._("event.loadFlows"),80 )
+        var flowsUrl = RED.settings.apiRootUrl + (RED.settings.flowsUrl || 'flows');
         $.ajax({
             headers: {
                 "Accept":"application/json",
             },
             cache: false,
-            url: 'flows',
+            url: flowsUrl,
             success: function(nodes) {
                 if (nodes) {
                     var currentHash = window.location.hash;

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
@@ -336,8 +336,9 @@ RED.deploy = (function() {
         deployInflight = true
         deployButtonSetBusy()
         shadeShow()
+        var flowsUrl = RED.settings.apiRootUrl + (RED.settings.flowsUrl || 'flows');
         $.ajax({
-            url:"flows/state",
+            url: flowsUrl + "/state",
             type: "POST",
             data: {state: state}
         }).done(function(data,textStatus,xhr) {
@@ -376,7 +377,7 @@ RED.deploy = (function() {
         deployInflight = true;
         deployButtonSetBusy();
         $.ajax({
-            url:"flows",
+            url: flowsUrl,
             type: "POST",
             headers: {
                 "Node-RED-Deployment-Type":"reload"

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/diff.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/diff.js
@@ -1111,12 +1111,13 @@ RED.diff = (function() {
         }
     }
     function getRemoteDiff(callback) {
+        var flowsUrl = RED.settings.apiRootUrl + (RED.settings.flowsUrl || 'flows');
         $.ajax({
             headers: {
                 "Accept":"application/json",
             },
             cache: false,
-            url: 'flows',
+            url: flowsUrl,
             success: function(nodes) {
                 var localFlow = RED.nodes.createCompleteNodeSet();
                 var originalFlow = RED.nodes.originalFlow();

--- a/packages/node_modules/@node-red/runtime/lib/api/settings.js
+++ b/packages/node_modules/@node-red/runtime/lib/api/settings.js
@@ -75,6 +75,7 @@ var api = module.exports = {
     getRuntimeSettings: async function(opts) {
         var safeSettings = {
             httpNodeRoot: runtime.settings.httpNodeRoot||"/",
+            flowsUrl: runtime.settings.flowsUrl || "/flows",
             version: runtime.settings.version
         }
         if (opts.user) {

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -193,6 +193,9 @@ module.exports = {
      */
     //httpNodeRoot: '/red-nodes',
 
+    /** The base path used for the runtime flows API. */
+    flowsUrl: process.env.NODE_RED_FLOWS_URL || '/flows',
+
     /** The following property can be used to configure cross-origin resource sharing
      * in the HTTP nodes.
      * See https://github.com/troygoode/node-cors#configuration-options for

--- a/test/unit/@node-red/editor-api/lib/admin/flows_spec.js
+++ b/test/unit/@node-red/editor-api/lib/admin/flows_spec.js
@@ -22,6 +22,8 @@ var sinon = require('sinon');
 
 var NR_TEST_UTILS = require("nr-test-utils");
 
+const flowsUrl = "/flows";
+
 var flows = NR_TEST_UTILS.require("@node-red/editor-api/lib/admin/flows");
 
 describe("api/admin/flows", function() {
@@ -31,10 +33,10 @@ describe("api/admin/flows", function() {
     before(function() {
         app = express();
         app.use(bodyParser.json());
-        app.get("/flows",flows.get);
-        app.get("/flows/state",flows.getState);
-        app.post("/flows",flows.post);
-        app.post("/flows/state",flows.postState);
+        app.get(flowsUrl, flows.get);
+        app.get(flowsUrl + "/state", flows.getState);
+        app.post(flowsUrl, flows.post);
+        app.post(flowsUrl + "/state", flows.postState);
     });
 
     it('returns flow - v1', function(done) {
@@ -44,7 +46,7 @@ describe("api/admin/flows", function() {
             }
         });
         request(app)
-            .get('/flows')
+            .get(flowsUrl)
             .set('Accept', 'application/json')
             .expect(200)
             .end(function(err,res) {
@@ -66,7 +68,7 @@ describe("api/admin/flows", function() {
             }
         });
         request(app)
-            .get('/flows')
+            .get(flowsUrl)
             .set('Accept', 'application/json')
             .set('Node-RED-API-Version','v2')
             .expect(200)
@@ -86,7 +88,7 @@ describe("api/admin/flows", function() {
     });
     it('returns flow - bad version', function(done) {
         request(app)
-            .get('/flows')
+            .get(flowsUrl)
             .set('Accept', 'application/json')
             .set('Node-RED-API-Version','xxx')
             .expect(400)
@@ -110,7 +112,7 @@ describe("api/admin/flows", function() {
             }
         });
         request(app)
-            .post('/flows')
+            .post(flowsUrl)
             .set('Accept', 'application/json')
             .expect(204)
             .end(function(err,res) {
@@ -130,7 +132,7 @@ describe("api/admin/flows", function() {
             }
         });
         request(app)
-            .post('/flows')
+            .post(flowsUrl)
             .set('Accept', 'application/json')
             .set('Node-RED-Deployment-Type','nodes')
             .expect(204)
@@ -158,7 +160,7 @@ describe("api/admin/flows", function() {
             }
         });
         request(app)
-            .post('/flows')
+            .post(flowsUrl)
             .set('Accept', 'application/json')
             .set('Node-RED-API-Version','v2')
             .send({rev:456,flows:[4,5,6]})
@@ -173,7 +175,7 @@ describe("api/admin/flows", function() {
     });
     it('sets flow - bad version', function(done) {
         request(app)
-            .post('/flows')
+            .post(flowsUrl)
             .set('Accept', 'application/json')
             .set('Node-RED-API-Version','xxx')
             .expect(400)
@@ -197,7 +199,7 @@ describe("api/admin/flows", function() {
             }
         });
         request(app)
-            .post('/flows')
+            .post(flowsUrl)
             .set('Accept', 'application/json')
             .set('Node-RED-Deployment-Type','reload')
             .expect(204)
@@ -221,7 +223,7 @@ describe("api/admin/flows", function() {
             }
         });
         request(app)
-            .get('/flows/state')
+            .get(flowsUrl + '/state')
             .set('Accept', 'application/json')
             .set('Node-RED-Deployment-Type', 'reload')
             .expect(200)
@@ -252,7 +254,7 @@ describe("api/admin/flows", function() {
             }
         });
         request(app)
-            .post('/flows/state')
+            .post(flowsUrl + '/state')
             .set('Accept', 'application/json')
             .send({state:'stop'})
             .expect(200)
@@ -293,7 +295,7 @@ describe("api/admin/flows", function() {
             }
         });
         request(app)
-            .post('/flows/state')
+            .post(flowsUrl + '/state')
             .set('Accept', 'application/json')
             .send({state:'bad-state'})
             .expect(400)

--- a/test/unit/@node-red/editor-api/lib/admin/index_spec.js
+++ b/test/unit/@node-red/editor-api/lib/admin/index_spec.js
@@ -109,8 +109,10 @@ describe("api/admin/index", function() {
             permissionChecks = {};
         });
 
+        const flowsUrl = "/flows";
+
         it('GET /flows', function(done) {
-            request(app).get("/flows").expect(200).end(function(err,res) {
+            request(app).get(flowsUrl).expect(200).end(function(err,res) {
                 if (err) {
                     return done(err);
                 }
@@ -120,7 +122,7 @@ describe("api/admin/index", function() {
         });
 
         it('POST /flows', function(done) {
-            request(app).post("/flows").expect(200).end(function(err,res) {
+            request(app).post(flowsUrl).expect(200).end(function(err,res) {
                 if (err) {
                     return done(err);
                 }


### PR DESCRIPTION
## Summary
- introduce `flowsUrl` setting using env `NODE_RED_FLOWS_URL`
- route admin API flows endpoints using `flowsUrl`
- expose `flowsUrl` via runtime settings
- use `flowsUrl` from the editor when calling flows endpoints

## Testing
- `npm test` *(fails: grunt not found due to no network access)*

------
https://chatgpt.com/codex/tasks/task_e_6864ebe5a3a48326b7886a40a644149e